### PR TITLE
Make second param truely optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,10 @@ var i10n = {
 ```
 
 Each property holds an array containing the singular and the plural-suffix.
+
+If you don't need to specify the `to`-parameter, you can pass in the localization as second parameter:
+
+``` js
+var i10n = {…};
+var elapsedTime = new Elapsed(from, i10n);
+```

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ var l10nDefaults = {
 
 function Elapsed (from, to, l10n) {
 	this.from = from;
-	this.to = to || new Date();
-	this.l10n = l10n || l10nDefaults;
+	this.to = arguments.length === 2 && to instanceof Date ? to : new Date();
+	this.l10n = arguments.length === 3 ? l10n : arguments.length === 2 && !(to instanceof Date) ? to : l10nDefaults;
 	if (!(this.from instanceof Date && this.to instanceof Date)) return;
 
 	this.set();

--- a/test.js
+++ b/test.js
@@ -50,3 +50,21 @@ console.log(localizedElapsedTime.months.text);
 console.log(localizedElapsedTime.years.text);
 
 console.log(localizedElapsedTime.optimal);
+
+var localizedElapsedTimeWithImplicitNow = new Elapsed(then, german);
+
+console.log(localizedElapsedTimeWithImplicitNow.seconds.text);
+
+console.log(localizedElapsedTimeWithImplicitNow.minutes.text);
+
+console.log(localizedElapsedTimeWithImplicitNow.hours.text);
+
+console.log(localizedElapsedTimeWithImplicitNow.days.text);
+
+console.log(localizedElapsedTimeWithImplicitNow.weeks.text);
+
+console.log(localizedElapsedTimeWithImplicitNow.months.text);
+
+console.log(localizedElapsedTimeWithImplicitNow.years.text);
+
+console.log(localizedElapsedTimeWithImplicitNow.optimal);


### PR DESCRIPTION
Fix to make it possible to just pass in the `then`-argument and the localization, without needing to provide an ugly `null` as second parameter.

```diff
- var elapsedTime = new Elapsed(from, null, i10n);
+ var elapsedTime = new Elapsed(from, i10n);
```